### PR TITLE
Add support for IAM roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# taskcat
+.taskcat/*
+taskcat_outputs/*

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,6 +1,6 @@
 project:
   name: cfn-ps-connect-integration-aspect-wfm
-  owner: support@aspect.com
+  owner: support@alvaria.com
   package_lambda: false
   regions:
   - us-east-1
@@ -8,10 +8,17 @@ tests:
   default:
     parameters:
       FirehoseStreamName: tcat-$[taskcat_random-string]
-      SignedOutStatuses: 'Offline'
+      SignedOutStatuses: ''
+      NumSQSQueues: 1
+      LambdaConfigLocation: tab
       ConnectS3Bucket: tcat-$[taskcat_random-string]
       ConnectS3Prefix: tcat-$[taskcat_random-string]/
       ConnectS3KmsArn: ''
+      AHGFilterLevel: 0
+      AHGFilterValues: ''
+      AuthorizationMode: User
+      SourceAwsAccountId: ''
+      ExternalId: ''
       QSS3BucketName: $[taskcat_autobucket]
       QSS3BucketRegion: $[taskcat_current_region]
     regions:
@@ -19,4 +26,4 @@ tests:
     - us-west-2
     - eu-central-1
     - ap-southeast-2
-    template: templates/aspect-wfm-ap-kda-create-stream.template.yaml
+    template: templates/aspect-wfm-ap-and-rta-create-stream.template.yaml

--- a/templates/aspect-wfm-ap-and-rta-create-stream.template.yaml
+++ b/templates/aspect-wfm-ap-and-rta-create-stream.template.yaml
@@ -23,6 +23,12 @@ Metadata:
       - AHGFilterSeparator
       - AHGFilterValues
     - Label:
+        default: IAM Configuration
+      Parameters:
+        - AuthorizationMode
+        - SourceAwsAccountId
+        - ExternalId
+    - Label:
         default: AWS Quick Start configuration
       Parameters:
       - QSS3BucketName
@@ -53,6 +59,12 @@ Metadata:
         default: Agent Hierarchy Group filter value separator
       AHGFilterValues:
         default: Agent Hierarchy Group filter matching values
+      AuthorizationMode:
+        default: Authorization Mode
+      SourceAwsAccountId:
+        default: Source AWS Account ID
+      ExternalId:
+        default: External ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
@@ -153,6 +165,33 @@ Parameters:
       be sent on to Real-Time Adherence and any agent events that do not match the filter will be discarded. Matching
       values should be separated with the character configured in AHGFilterSeparator.
     Type: String
+  AuthorizationMode:
+    Type: String
+    Description: Select User to create IAM Users for WFM Adapter and RTA. Select Role to create
+      IAM Roles for WFM Adapter and RTA. If WFM Adapter and RTA are running outside of AWS, you 
+      should select User. If WFM Adapter and RTA are running inside AWS, you should select Role.
+    Default: User
+    AllowedValues:
+      - User
+      - Role
+  SourceAwsAccountId:
+    Type: String
+    AllowedPattern: (^$|^[0-9]{12}$)
+    ConstraintDescription: If Authorization Mode is User, Source AWS Account ID should be
+      blank. If Authorization Mode is Role, Source AWS Account ID should be a 12-digit
+      number.
+    Description: Optional AWS account ID to include in the trust policy for the IAM Role.
+      The AWS account ID should match the AWS account from which WFM Adapter and RTA will 
+      assume their roles. This parameter is required when Authorization Mode is Role. This 
+      parameter will be ignored when Authorization Mode is User.
+  ExternalId:
+    Type: String
+    AllowedPattern: '^[0-9a-zA-Z+=,.@:\/-]*$'
+    ConstraintDescription: 'External ID values can include numbers, lowercase letters, uppercase letters, and the following special characters: + = , . @ : / -'
+    Description: Optional external ID to include in the trust policy for the IAM Roles. If
+      Authorization Mode is Role, the roles will be configured to require this external ID. 
+      You will need to configure WFM Adapter and RTA to supply this external ID when they assume 
+      their roles. If Authorization Mode is User, this parameter will be ignored.
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
@@ -185,6 +224,14 @@ Rules:
           - Ref: ConnectS3Prefix
           - connect/directory/Reports/Alvaria/
       AssertDescription: Replace directory with the directory name of your Amazon Connect instance.
+  RoleRequiredParameters:
+    RuleCondition: !Equals [!Ref AuthorizationMode, 'Role']
+    Assertions:
+    - Assert: !Not [!Equals [!Ref SourceAwsAccountId, '']]
+      AssertDescription: Source AWS Account ID is required when Authorization Mode
+        is Role.
+    - Assert: !Not [!Equals [!Ref ExternalId, '']]
+      AssertDescription: External ID is required when Authorization Mode is Role.
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-ia']
 Resources:
@@ -212,6 +259,9 @@ Resources:
         ConnectS3Bucket: !Ref ConnectS3Bucket
         ConnectS3Prefix: !Ref ConnectS3Prefix
         ConnectS3KmsArn: !Ref ConnectS3KmsArn
+        AuthorizationMode: !Ref AuthorizationMode
+        SourceAwsAccountId: !Ref SourceAwsAccountId
+        ExternalId: !Ref ExternalId
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
@@ -234,6 +284,9 @@ Resources:
         AHGFilterLevel: !Ref AHGFilterLevel
         AHGFilterSeparator: !Ref AHGFilterSeparator
         AHGFilterValues: !Ref AHGFilterValues
+        AuthorizationMode: !Ref AuthorizationMode
+        SourceAwsAccountId: !Ref SourceAwsAccountId
+        ExternalId: !Ref ExternalId
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
@@ -268,6 +321,11 @@ Outputs:
       Fn::GetAtt:
       - ApStack
       - Outputs.WFMAdapterUserName
+  WFMAdapterRoleARN:
+    Value:
+      Fn::GetAtt:
+      - ApStack
+      - Outputs.WFMAdapterRoleARN
   DynamoDbTableName:
     Value:
       Fn::GetAtt:
@@ -338,4 +396,9 @@ Outputs:
       Fn::GetAtt:
       - RtaStack
       - Outputs.RTAUserName
+  RTARoleARN:
+    Value:
+      Fn::GetAtt:
+      - RtaStack
+      - Outputs.RTARoleARN
 ...

--- a/templates/aspect-wfm-ap-and-rta.template.yaml
+++ b/templates/aspect-wfm-ap-and-rta.template.yaml
@@ -25,6 +25,12 @@ Metadata:
       - AHGFilterSeparator
       - AHGFilterValues
     - Label:
+        default: IAM Configuration
+      Parameters:
+        - AuthorizationMode
+        - SourceAwsAccountId
+        - ExternalId
+    - Label:
         default: AWS Quick Start configuration
       Parameters:
       - QSS3BucketName
@@ -59,6 +65,12 @@ Metadata:
         default: Agent Hierarchy Group filter value separator
       AHGFilterValues:
         default: Agent Hierarchy Group filter matching values
+      AuthorizationMode:
+        default: Authorization Mode
+      SourceAwsAccountId:
+        default: Source AWS Account ID
+      ExternalId:
+        default: External ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
@@ -169,6 +181,33 @@ Parameters:
       be sent on to Real-Time Adherence and any agent events that do not match the filter will be discarded. Matching
       values should be separated with the character configured in AHGFilterSeparator.
     Type: String
+  AuthorizationMode:
+    Type: String
+    Description: Select User to create IAM Users for WFM Adapter and RTA. Select Role to create
+      IAM Roles for WFM Adapter and RTA. If WFM Adapter and RTA are running outside of AWS, you 
+      should select User. If WFM Adapter and RTA are running inside AWS, you should select Role.
+    Default: User
+    AllowedValues:
+      - User
+      - Role
+  SourceAwsAccountId:
+    Type: String
+    AllowedPattern: (^$|^[0-9]{12}$)
+    ConstraintDescription: If Authorization Mode is User, Source AWS Account ID should be
+      blank. If Authorization Mode is Role, Source AWS Account ID should be a 12-digit
+      number.
+    Description: Optional AWS account ID to include in the trust policy for the IAM Role.
+      The AWS account ID should match the AWS account from which WFM Adapter and RTA will 
+      assume their roles. This parameter is required when Authorization Mode is Role. This 
+      parameter will be ignored when Authorization Mode is User.
+  ExternalId:
+    Type: String
+    AllowedPattern: '^[0-9a-zA-Z+=,.@:\/-]*$'
+    ConstraintDescription: 'External ID values can include numbers, lowercase letters, uppercase letters, and the following special characters: + = , . @ : / -'
+    Description: Optional external ID to include in the trust policy for the IAM Roles. If
+      Authorization Mode is Role, the roles will be configured to require this external ID. 
+      You will need to configure WFM Adapter and RTA to supply this external ID when they assume 
+      their roles. If Authorization Mode is User, this parameter will be ignored.
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
@@ -201,6 +240,14 @@ Rules:
           - Ref: ConnectS3Prefix
           - connect/directory/Reports/Alvaria/
       AssertDescription: Replace directory with the directory name of your Amazon Connect instance.
+  RoleRequiredParameters:
+    RuleCondition: !Equals [!Ref AuthorizationMode, 'Role']
+    Assertions:
+    - Assert: !Not [!Equals [!Ref SourceAwsAccountId, '']]
+      AssertDescription: Source AWS Account ID is required when Authorization Mode
+        is Role.
+    - Assert: !Not [!Equals [!Ref ExternalId, '']]
+      AssertDescription: External ID is required when Authorization Mode is Role.
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-ia']
 Resources:
@@ -222,6 +269,9 @@ Resources:
         ConnectS3KmsArn: !Ref ConnectS3KmsArn
         AgentEventStreamArn: !Ref AgentEventStreamArn
         AgentEventStreamKmsArn: !Ref AgentEventStreamKmsArn
+        AuthorizationMode: !Ref AuthorizationMode
+        SourceAwsAccountId: !Ref SourceAwsAccountId
+        ExternalId: !Ref ExternalId
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
@@ -241,6 +291,9 @@ Resources:
         AHGFilterLevel: !Ref AHGFilterLevel
         AHGFilterSeparator: !Ref AHGFilterSeparator
         AHGFilterValues: !Ref AHGFilterValues
+        AuthorizationMode: !Ref AuthorizationMode
+        SourceAwsAccountId: !Ref SourceAwsAccountId
+        ExternalId: !Ref ExternalId
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
@@ -265,6 +318,11 @@ Outputs:
       Fn::GetAtt:
       - ApStack
       - Outputs.WFMAdapterUserName
+  WFMAdapterRoleARN:
+    Value:
+      Fn::GetAtt:
+      - ApStack
+      - Outputs.WFMAdapterRoleARN
   DynamoDbTableName:
     Value:
       Fn::GetAtt:
@@ -335,4 +393,9 @@ Outputs:
       Fn::GetAtt:
       - RtaStack
       - Outputs.RTAUserName
+  RTARoleARN:
+    Value:
+      Fn::GetAtt:
+      - RtaStack
+      - Outputs.RTARoleARN
 ...

--- a/templates/aspect-wfm-ap-kda-create-stream.template.yaml
+++ b/templates/aspect-wfm-ap-kda-create-stream.template.yaml
@@ -18,6 +18,12 @@ Metadata:
       - ConnectS3Prefix
       - ConnectS3KmsArn
     - Label:
+        default: IAM Configuration
+      Parameters:
+        - AuthorizationMode
+        - SourceAwsAccountId
+        - ExternalId
+    - Label:
         default: AWS Quick Start configuration
       Parameters:
       - QSS3BucketName
@@ -38,6 +44,12 @@ Metadata:
         default: Amazon Connect Exported Reports Prefix
       ConnectS3KmsArn:
         default: Amazon Connect Exported Reports Bucket KMS Key ARN
+      AuthorizationMode:
+        default: Authorization Mode
+      SourceAwsAccountId:
+        default: Source AWS Account ID
+      ExternalId:
+        default: External ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
@@ -107,6 +119,33 @@ Parameters:
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
       or end with a hyphen (-).
     Type: String
+  AuthorizationMode:
+    Type: String
+    Description: Select User to create an IAM User for WFM Adapter. Select Role to create
+      an IAM Role for WFM Adapter. If WFM Adapter is running outside of AWS, you should
+      select User. If WFM Adapter is running inside AWS, you should select Role.
+    Default: User
+    AllowedValues:
+      - User
+      - Role
+  SourceAwsAccountId:
+    Type: String
+    AllowedPattern: (^$|^[0-9]{12}$)
+    ConstraintDescription: If Authorization Mode is User, Source AWS Account ID should be
+      blank. If Authorization Mode is Role, Source AWS Account ID should be a 12-digit
+      number.
+    Description: Optional AWS account ID to include in the trust policy for the IAM Role.
+      The AWS account ID should match the AWS account from which WFM Adapter will assume
+      the role. This parameter is required when Authorization Mode is Role. This parameter 
+      will be ignored when Authorization Mode is User.
+  ExternalId:
+    Type: String
+    AllowedPattern: '^[0-9a-zA-Z+=,.@:\/-]*$'
+    ConstraintDescription: 'External ID values can include numbers, lowercase letters, uppercase letters, and the following special characters: + = , . @ : / -'
+    Description: Optional external ID to include in the trust policy for the IAM Role. If
+      Authorization Mode is Role, the role will be configured to require this external ID. 
+      You will need to configure WFM Adapter to supply this external ID when it assumes the 
+      role. If Authorization Mode is User, this parameter will be ignored.
   QSS3BucketRegion:
     Default: 'us-east-1'
     Description: 'The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value.'
@@ -130,6 +169,14 @@ Rules:
           - connect/directory/Reports/Alvaria/
       AssertDescription: Replace directory with the directory name of your Amazon
         Connect instance.
+  RoleRequiredParameters:
+    RuleCondition: !Equals [!Ref AuthorizationMode, 'Role']
+    Assertions:
+    - Assert: !Not [!Equals [!Ref SourceAwsAccountId, '']]
+      AssertDescription: Source AWS Account ID is required when Authorization Mode
+        is Role.
+    - Assert: !Not [!Equals [!Ref ExternalId, '']]
+      AssertDescription: External ID is required when Authorization Mode is Role.
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-ia']
 Resources:
@@ -158,6 +205,9 @@ Resources:
         ConnectS3Bucket: !Ref ConnectS3Bucket
         ConnectS3Prefix: !Ref ConnectS3Prefix
         ConnectS3KmsArn: !Ref ConnectS3KmsArn
+        AuthorizationMode: !Ref AuthorizationMode
+        SourceAwsAccountId: !Ref SourceAwsAccountId
+        ExternalId: !Ref ExternalId
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
@@ -192,4 +242,9 @@ Outputs:
       Fn::GetAtt:
       - WorkloadStack
       - Outputs.WFMAdapterUserName
+  WFMAdapterRoleARN:
+    Value:
+      Fn::GetAtt:
+      - WorkloadStack
+      - Outputs.WFMAdapterRoleARN
 ...

--- a/templates/aspect-wfm-ap-kda.template.yaml
+++ b/templates/aspect-wfm-ap-kda.template.yaml
@@ -21,6 +21,12 @@ Metadata:
       - AgentEventStreamArn
       - AgentEventStreamKmsArn
     - Label:
+        default: IAM Configuration
+      Parameters:
+        - AuthorizationMode
+        - SourceAwsAccountId
+        - ExternalId
+    - Label:
         default: AWS Quick Start configuration
       Parameters:
         - QSS3BucketName
@@ -45,6 +51,12 @@ Metadata:
         default: Agent Event Kinesis Stream ARN
       AgentEventStreamKmsArn:
         default: Agent Event Kinesis Stream KMS Key ARN
+      AuthorizationMode:
+        default: Authorization Mode
+      SourceAwsAccountId:
+        default: Source AWS Account ID
+      ExternalId:
+        default: External ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
@@ -114,6 +126,33 @@ Parameters:
       agent events. You should supply this ARN if you configured your Agent Event Kinesis
       stream to use server-side encryption with an AWS Key Management Service (KMS) key.
       Otherwise, you should leave this parameter blank.
+  AuthorizationMode:
+    Type: String
+    Description: Select User to create an IAM User for WFM Adapter. Select Role to create
+      an IAM Role for WFM Adapter. If WFM Adapter is running outside of AWS, you should
+      select User. If WFM Adapter is running inside AWS, you should select Role.
+    Default: User
+    AllowedValues:
+      - User
+      - Role
+  SourceAwsAccountId:
+    Type: String
+    AllowedPattern: (^$|^[0-9]{12}$)
+    ConstraintDescription: If Authorization Mode is User, Source AWS Account ID should be
+      blank. If Authorization Mode is Role, Source AWS Account ID should be a 12-digit
+      number.
+    Description: Optional AWS account ID to include in the trust policy for the IAM Role.
+      The AWS account ID should match the AWS account from which WFM Adapter will assume
+      the role. This parameter is required when Authorization Mode is Role. This parameter 
+      will be ignored when Authorization Mode is User.
+  ExternalId:
+    Type: String
+    AllowedPattern: '^[0-9a-zA-Z+=,.@:\/-]*$'
+    ConstraintDescription: 'External ID values can include numbers, lowercase letters, uppercase letters, and the following special characters: + = , . @ : / -'
+    Description: Optional external ID to include in the trust policy for the IAM Role. If
+      Authorization Mode is Role, the role will be configured to require this external ID. 
+      You will need to configure WFM Adapter to supply this external ID when it assumes the 
+      role. If Authorization Mode is User, this parameter will be ignored.
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
@@ -147,10 +186,20 @@ Rules:
           - connect/directory/Reports/Alvaria/
       AssertDescription: Replace directory with the directory name of your Amazon
         Connect instance.
+  RoleRequiredParameters:
+    RuleCondition: !Equals [!Ref AuthorizationMode, 'Role']
+    Assertions:
+    - Assert: !Not [!Equals [!Ref SourceAwsAccountId, '']]
+      AssertDescription: Source AWS Account ID is required when Authorization Mode
+        is Role.
+    - Assert: !Not [!Equals [!Ref ExternalId, '']]
+      AssertDescription: External ID is required when Authorization Mode is Role.
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-ia']
   HasS3KmsKey: !Not [!Equals [!Ref ConnectS3KmsArn, '']]
   HasKinesisKmsKey: !Not [!Equals [!Ref AgentEventStreamKmsArn, '']]
+  CreateUser: !Equals [!Ref AuthorizationMode, 'User']
+  CreateRole: !Equals [!Ref AuthorizationMode, 'Role']
 Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
@@ -379,15 +428,35 @@ Resources:
       FunctionName: !Ref KinesisLambdaFunction
       StartingPosition: LATEST
   WFMAdapterUser:
+    Condition: CreateUser
     Type: AWS::IAM::User
+  WFMAdapterRole:
+    Condition: CreateRole
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            AWS: 
+              !Sub
+                - "arn:aws:iam::${accountId}:root"
+                - accountId: !Ref SourceAwsAccountId
+          Action: sts:AssumeRole
+          Condition: 
+            StringEquals:
+              "sts:ExternalId": !Ref ExternalId
   WFMAdapterReadS3Policy:
     Type: AWS::IAM::Policy
     DependsOn:
     - S3Bucket
     Properties:
       PolicyName: WFMAdapter_ReadS3Policy
+      Roles:
+      - !If [CreateRole, !Ref WFMAdapterRole, !Ref 'AWS::NoValue']
       Users:
-      - !Ref WFMAdapterUser
+      - !If [CreateUser, !Ref WFMAdapterUser, !Ref 'AWS::NoValue']
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -405,8 +474,10 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       PolicyName: WFMAdapter_DecryptS3Policy
+      Roles:
+      - !If [CreateRole, !Ref WFMAdapterRole, !Ref 'AWS::NoValue']
       Users:
-      - !Ref WFMAdapterUser
+      - !If [CreateUser, !Ref WFMAdapterUser, !Ref 'AWS::NoValue']
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -425,4 +496,6 @@ Outputs:
   APKinesisLambdaFunctionName:
     Value: !Ref KinesisLambdaFunction
   WFMAdapterUserName:
-    Value: !Ref WFMAdapterUser
+    Value: !If [CreateUser, !Ref WFMAdapterUser, '']
+  WFMAdapterRoleARN:
+    Value: !If [CreateRole, !GetAtt WFMAdapterRole.Arn, '']

--- a/templates/aspect-wfm-rta-create-stream.template.yaml
+++ b/templates/aspect-wfm-rta-create-stream.template.yaml
@@ -16,6 +16,12 @@ Metadata:
           - AHGFilterSeparator
           - AHGFilterValues
       - Label:
+          default: IAM Configuration
+        Parameters:
+          - AuthorizationMode
+          - SourceAwsAccountId
+          - ExternalId
+      - Label:
           default: AWS Quick Start configuration
         Parameters:
           - QSS3BucketName
@@ -32,6 +38,12 @@ Metadata:
         default: Agent Hierarchy Group filter value separator
       AHGFilterValues:
         default: Agent Hierarchy Group filter matching values
+      AuthorizationMode:
+        default: Authorization Mode
+      SourceAwsAccountId:
+        default: Source AWS Account ID
+      ExternalId:
+        default: External ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
@@ -81,6 +93,33 @@ Parameters:
       be sent on to Real-Time Adherence and any agent events that do not match the filter will be discarded. Matching
       values should be separated with the character configured in AHGFilterSeparator.
     Type: String
+  AuthorizationMode:
+    Type: String
+    Description: Select User to create an IAM User for RTA. Select Role to create
+      an IAM Role for RTA. If RTA is running outside of AWS, you should
+      select User. If RTA is running inside AWS, you should select Role.
+    Default: User
+    AllowedValues:
+      - User
+      - Role
+  SourceAwsAccountId:
+    Type: String
+    AllowedPattern: (^$|^[0-9]{12}$)
+    ConstraintDescription: If Authorization Mode is User, Source AWS Account ID should be
+      blank. If Authorization Mode is Role, Source AWS Account ID should be a 12-digit
+      number.
+    Description: Optional AWS account ID to include in the trust policy for the IAM Role.
+      The AWS account ID should match the AWS account from which RTA will assume
+      the role. This parameter is required when Authorization Mode is Role. This parameter 
+      will be ignored when Authorization Mode is User.
+  ExternalId:
+    Type: String
+    AllowedPattern: '^[0-9a-zA-Z+=,.@:\/-]*$'
+    ConstraintDescription: 'External ID values can include numbers, lowercase letters, uppercase letters, and the following special characters: + = , . @ : / -'
+    Description: Optional external ID to include in the trust policy for the IAM Role. If
+      Authorization Mode is Role, the role will be configured to require this external ID. 
+      You will need to configure RTA to supply this external ID when it assumes the 
+      role. If Authorization Mode is User, this parameter will be ignored.
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription:
@@ -143,6 +182,9 @@ Resources:
         AHGFilterLevel: !Ref AHGFilterLevel
         AHGFilterSeparator: !Ref AHGFilterSeparator
         AHGFilterValues: !Ref AHGFilterValues
+        AuthorizationMode: !Ref AuthorizationMode
+        SourceAwsAccountId: !Ref SourceAwsAccountId
+        ExternalId: !Ref ExternalId
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
@@ -227,3 +269,8 @@ Outputs:
       Fn::GetAtt:
         - WorkloadStack
         - Outputs.RTAUserName
+  RTARoleARN:
+    Value:
+      Fn::GetAtt:
+        - WorkloadStack
+        - Outputs.RTARoleARN

--- a/templates/aspect-wfm-rta.template.yaml
+++ b/templates/aspect-wfm-rta.template.yaml
@@ -18,6 +18,12 @@ Metadata:
         - AHGFilterSeparator
         - AHGFilterValues
     - Label:
+        default: IAM Configuration
+      Parameters:
+        - AuthorizationMode
+        - SourceAwsAccountId
+        - ExternalId
+    - Label:
         default: AWS Quick Start configuration
       Parameters:
         - QSS3BucketName
@@ -38,6 +44,12 @@ Metadata:
         default: Agent Hierarchy Group filter value separator
       AHGFilterValues:
         default: Agent Hierarchy Group filter matching values
+      AuthorizationMode:
+        default: Authorization Mode
+      SourceAwsAccountId:
+        default: Source AWS Account ID
+      ExternalId:
+        default: External ID
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3BucketRegion:
@@ -100,6 +112,33 @@ Parameters:
       be sent on to Real-Time Adherence and any agent events that do not match the filter will be discarded. Matching
       values should be separated with the character configured in AHGFilterSeparator.
     Type: String
+  AuthorizationMode:
+    Type: String
+    Description: Select User to create an IAM User for RTA. Select Role to create
+      an IAM Role for RTA. If RTA is running outside of AWS, you should
+      select User. If RTA is running inside AWS, you should select Role.
+    Default: User
+    AllowedValues:
+      - User
+      - Role
+  SourceAwsAccountId:
+    Type: String
+    AllowedPattern: (^$|^[0-9]{12}$)
+    ConstraintDescription: If Authorization Mode is User, Source AWS Account ID should be
+      blank. If Authorization Mode is Role, Source AWS Account ID should be a 12-digit
+      number.
+    Description: Optional AWS account ID to include in the trust policy for the IAM Role.
+      The AWS account ID should match the AWS account from which RTA will assume
+      the role. This parameter is required when Authorization Mode is Role. This parameter 
+      will be ignored when Authorization Mode is User.
+  ExternalId:
+    Type: String
+    AllowedPattern: '^[0-9a-zA-Z+=,.@:\/-]*$'
+    ConstraintDescription: 'External ID values can include numbers, lowercase letters, uppercase letters, and the following special characters: + = , . @ : / -'
+    Description: Optional external ID to include in the trust policy for the IAM Role. If
+      Authorization Mode is Role, the role will be configured to require this external ID. 
+      You will need to configure RTA to supply this external ID when it assumes the 
+      role. If Authorization Mode is User, this parameter will be ignored.
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
@@ -119,6 +158,15 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
     Type: String
+Rules:
+  RoleRequiredParameters:
+    RuleCondition: !Equals [!Ref AuthorizationMode, 'Role']
+    Assertions:
+    - Assert: !Not [!Equals [!Ref SourceAwsAccountId, '']]
+      AssertDescription: Source AWS Account ID is required when Authorization Mode
+        is Role.
+    - Assert: !Not [!Equals [!Ref ExternalId, '']]
+      AssertDescription: External ID is required when Authorization Mode is Role.
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-ia']
   HasKinesisKmsKey: !Not [!Equals [!Ref AgentEventStreamKmsArn, '']]
@@ -156,6 +204,8 @@ Conditions:
   CreateSqsQ10: !Equals [10, !Ref NumSQSQueues]
   FlagInEnv: !Equals ["env", !Ref LambdaConfigLocation]
   FlagInTable: !Equals ["tab", !Ref LambdaConfigLocation]
+  CreateUser: !Equals [!Ref AuthorizationMode, 'User']
+  CreateRole: !Equals [!Ref AuthorizationMode, 'Role']
 Resources:
   LambdaZipsBucket:
     Type: AWS::S3::Bucket
@@ -440,15 +490,35 @@ Resources:
       FunctionName: !Ref LambdaFunction
       StartingPosition: TRIM_HORIZON
   RtaUser:
+    Condition: CreateUser
     Type: AWS::IAM::User
+  RtaRole:
+    Condition: CreateRole
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            AWS: 
+              !Sub
+                - "arn:aws:iam::${accountId}:root"
+                - accountId: !Ref SourceAwsAccountId
+          Action: sts:AssumeRole
+          Condition: 
+            StringEquals:
+              "sts:ExternalId": !Ref ExternalId
   RtaReadAgentEventTablePolicy:
     Type: AWS::IAM::Policy
     DependsOn:
     - DynamoDbAgentEvent
     Properties:
       PolicyName: RTA_ReadAgentEventTablePolicy
+      Roles:
+      - !If [CreateRole, !Ref RtaRole, !Ref 'AWS::NoValue']
       Users:
-      - !Ref RtaUser
+      - !If [CreateUser, !Ref RtaUser, !Ref 'AWS::NoValue']
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -466,8 +536,10 @@ Resources:
     - DynamoDbConfig
     Properties:
       PolicyName: RTA_ReadWriteConfigTablePolicy
+      Roles:
+      - !If [CreateRole, !Ref RtaRole, !Ref 'AWS::NoValue']
       Users:
-      - !Ref RtaUser
+      - !If [CreateUser, !Ref RtaUser, !Ref 'AWS::NoValue']
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -486,8 +558,10 @@ Resources:
     - SqsQ
     Properties:
       PolicyName: RTA_ReadWriteSqsPolicy
+      Roles:
+      - !If [CreateRole, !Ref RtaRole, !Ref 'AWS::NoValue']
       Users:
-      - !Ref RtaUser
+      - !If [CreateUser, !Ref RtaUser, !Ref 'AWS::NoValue']
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -515,8 +589,10 @@ Resources:
     - LambdaFunction
     Properties:
       PolicyName: RTA_ReadWriteLambdaConfigurationPolicy
+      Roles:
+      - !If [CreateRole, !Ref RtaRole, !Ref 'AWS::NoValue']
       Users:
-      - !Ref RtaUser
+      - !If [CreateUser, !Ref RtaUser, !Ref 'AWS::NoValue']
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -554,5 +630,7 @@ Outputs:
   RTALambdaFunctionName:
     Value: !Ref LambdaFunction
   RTAUserName:
-    Value: !Ref RtaUser
+    Value: !If [CreateUser, !Ref RtaUser, '']
+  RTARoleARN:
+    Value: !If [CreateRole, !GetAtt RtaRole.Arn, '']
 ...


### PR DESCRIPTION
Update the AP and RTA templates to support two different authorization modes: User or Role
In User mode, the templates create IAM users. In Role mode, the templates create IAM roles
Also, update the e2e tests to use the AP and RTA template to cover both AP and RTA functionality in the e2e tests.